### PR TITLE
TOC: fix page number for the List of Tables

### DIFF
--- a/layout/frontmatter.tex
+++ b/layout/frontmatter.tex
@@ -121,8 +121,9 @@ proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 % 8b. List of Tables (remove if no tables)
 \clearpage
 \phantomsection
-\listoftables
 \addcontentsline{toc}{chapter}{List of Tables}
+\listoftables
+
 
 % 9. List of Appendicies (remove if no appendices)
 \clearpage


### PR DESCRIPTION
- Table of contents: the previous version produces incorrect page number of **List of Tables** entry, if the **List of Tables** has more than one page