### PR TITLE
Conform to Rackham recommendations

### DIFF
--- a/layout/frontmatter.tex
+++ b/layout/frontmatter.tex
@@ -57,8 +57,8 @@
 \begin{center}
 \begin{onehalfspacing}
   Jan Banan \\
-  \href{mailto:jan.banan@umich.edu}{jan.banan@umich.edu} \\
-  ORCID iD: \href{http://orcid.org/9999-9999-9999-9999}{9999-9999-9999-9999}\\
+  \href{mailto:jan.banan@umich.edu}{\color{black}jan.banan@umich.edu} \\
+  ORCID iD: \href{http://orcid.org/9999-9999-9999-9999}{\color{black}9999-9999-9999-9999}\\
   \vspace{0.3in}
   \copyright\;Jan Banan 2017
 \end{onehalfspacing}
@@ -77,62 +77,66 @@
 
 % 4. Dedication (optional)
 \chapter{Dedication}
-
+\begin{onehalfspace}
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
 quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
 cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
 proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+\end{onehalfspace}
 
 % 5. Acknowledgements (optional)
 \chapter{Acknowledgments}
-
+\begin{onehalfspace}
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
 quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
 cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
 proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+\end{onehalfspace}
 
 % 6. Preface (optional)
 \chapter{Preface}
-
+\begin{onehalfspace}
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
 tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
 quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
 cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
 proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+\end{onehalfspace}
 
 
 % 7. Table of Contents
 \clearpage
 \phantomsection\pdfbookmark{\contentsname}{toc}
 \renewcommand*{\contentsname}{Table of Contents}
-\tableofcontents
+{\hypersetup{linkcolor=black}\tableofcontents}
 
 % 8a. List of Figures (remove if no figures)
 \clearpage
 \phantomsection
 \addcontentsline{toc}{chapter}{\listfigurename}
-\listoffigures
+{\hypersetup{linkcolor=black}\listoffigures}
 
 % 8b. List of Tables (remove if no tables)
 \clearpage
 \phantomsection
 \addcontentsline{toc}{chapter}{List of Tables}
-\listoftables
+{\hypersetup{linkcolor=black}\listoftables}
 
 
 % 9. List of Appendicies (remove if no appendices)
 \clearpage
-\listofappendices
+{\hypersetup{linkcolor=black}\listofappendices}
 
 % 10a. List of Acronyms (optional)
 \clearpage
-\printglossary[type=\acronymtype, title={List of Acronyms}]
+\phantomsection
 \addcontentsline{toc}{chapter}{List of Acronyms}
+\printglossary[type=\acronymtype, title={List of Acronyms}]
 
 % 10b. List of Symbols (optional)
 \chapter{List of Symbols}

--- a/layout/notation.tex
+++ b/layout/notation.tex
@@ -1,7 +1,6 @@
 %!TEX root = ../um-thesis.tex
 
 \begin{longtable}{llll}
-    \toprule
     \endfirsthead
     %
     \toprule
@@ -12,7 +11,6 @@
     \bottomrule
     \endfoot
     %
-    \bottomrule
     \endlastfoot
     %
 

--- a/layout/preamble.tex
+++ b/layout/preamble.tex
@@ -23,15 +23,19 @@
 % \setmathfont{Libertinus Math} 
 
 % Font control (family/series/size etc) for different elements
-\setkomafont{sectioning}{\sffamily\bfseries}      % titles (chapter, section, etc)
-\setkomafont{title}{\sffamily\bfseries\Large}			% thesis title
-\setkomafont{caption}{\rmfamily\bfseries\small}
-\setkomafont{captionlabel}{\rmfamily\bfseries\small}
+\setkomafont{sectioning}{\bfseries}  % titles (chapter, section, etc)
+\setkomafont{title}{\bfseries\Large} % thesis title
+\setkomafont{caption}{\bfseries\small}
+\setkomafont{captionlabel}{\bfseries\small}
 
 %%%%%%%%%%%%%%%
 
 % Prefix chapters with 'Chapter'
 \KOMAoption{chapterprefix}{true}
+\renewcommand*{\chapterformat}{%
+  \mbox{\chapappifchapterprefix{\nobreakspace}\thechapter
+  \IfUsePrefixLine{}{\enskip}}%
+}
 
 % Continuous footnote numbering
 \usepackage{chngcntr}
@@ -78,7 +82,7 @@
             linktoc=all,
             linkcolor={blue!50!black}, 
             citecolor={blue!50!black}, 
-            urlcolor={red!50!black}]{hyperref}
+            urlcolor={blue!50!black}]{hyperref}
 
 % Add "Appendices" to toc
 \xapptocmd{\appendix}{


### PR DESCRIPTION
This pull request addresses a few issues brought up during my pre-defense review with Rackham. Most notably:
- Title page: Use the same font face for the title as used for the rest of the dissertation.
- Section headings: Same as the above.
- Links may only appear in blue, green, or purple.
- Acknowledgements must be at least 1.5 line spaced.
- Front matter should appear in black text.
- Table of Contents: For acronym lists greater than two pages, the correct start page should now be displayed.
- List of Symbols: Remove the lines.
- Chapter headers: Remove the period after the chapter headers.